### PR TITLE
Added retries and fails more gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from os import environ
 
 from polaris import Polaris
@@ -9,41 +10,47 @@ from google import Google
 logger = logging.getLogger('polaris-slack')
 
 def main():
-    polaris_url = environ.get('POLARIS_URL')
-    token = environ.get('POLARIS_TOKEN')
+    try:
+        polaris_url = environ.get('POLARIS_URL')
+        token = environ.get('POLARIS_TOKEN')
+        retries = int(environ.get('POLARIS_RETRIES', 1))  # Default to 1 if not set
+        wait_seconds = int(environ.get('POLARIS_WAIT_SECONDS', 60))  # Default to 60 if not set
 
-    if not polaris_url:
-        logger.critical("Environment variable POLARIS_URL is unset")
-    if not token:
-        logger.critical("Environment variable POLARIS_TOKEN is unset")
-    if not polaris_url or not token:
-        exit(1)
+        if not polaris_url:
+            logger.critical("Environment variable POLARIS_URL is unset")
+        if not token:
+            logger.critical("Environment variable POLARIS_TOKEN is unset")
+        if not polaris_url or not token:
+            exit(1)
 
-    slack_webhook_url = environ.get('SLACK_WEBHOOK_URL')
-    google_spaces_url = environ.get('GOOGLE_SPACES_URL')
-    if (not slack_webhook_url) and (not google_spaces_url):
-        logger.warning("Environment SLACK_WEBHOOK and GOOGLE_SPACES_URL is unset, just outputting issues to console.")
+        slack_webhook_url = environ.get('SLACK_WEBHOOK_URL')
+        google_spaces_url = environ.get('GOOGLE_SPACES_URL')
+        if (not slack_webhook_url) and (not google_spaces_url):
+            logger.warning("Environment SLACK_WEBHOOK and GOOGLE_SPACES_URL is unset, just outputting issues to console.")
 
-    polaris = Polaris(polaris_url, token)
+        polaris = Polaris(polaris_url, token, retries=retries, wait_seconds=wait_seconds)
 
-    filter = {
-        'only-security': environ.get('POLARIS_FILTER_ONLY_SECURITY'),
-        'only-untriaged': environ.get('POLARIS_FILTER_ONLY_UNTRIAGED'),
-    }
-    filter_untriaged = filter.copy()
-    filter_untriaged['only-untriaged'] = True
+        filter = {
+            'only-security': environ.get('POLARIS_FILTER_ONLY_SECURITY'),
+            'only-untriaged': environ.get('POLARIS_FILTER_ONLY_UNTRIAGED'),
+        }
+        filter_untriaged = filter.copy()
+        filter_untriaged['only-untriaged'] = True
 
-    projects_with_issues = polaris.GetProjectsAndIssues(filter)
+        projects_with_issues = polaris.GetProjectsAndIssues(filter)
 
-    if slack_webhook_url:
-        slack = Slack(slack_webhook_url)
-        slack.SendSummaryPerProjects(projects_with_issues, filter)
-    elif google_spaces_url:
-        projects_with_untriaged_issues = polaris.GetProjectsAndIssues(filter_untriaged)
-        google = Google(google_spaces_url)
-        google.SendSummaryMessage(projects_with_issues, projects_with_untriaged_issues, filter)
-    else:
-        print(json.dumps(projects_with_issues, indent=2))
+        if slack_webhook_url:
+            slack = Slack(slack_webhook_url)
+            slack.SendSummaryPerProjects(projects_with_issues, filter)
+        elif google_spaces_url:
+            projects_with_untriaged_issues = polaris.GetProjectsAndIssues(filter_untriaged)
+            google = Google(google_spaces_url)
+            google.SendSummaryMessage(projects_with_issues, projects_with_untriaged_issues, filter)
+        else:
+            print(json.dumps(projects_with_issues, indent=2))
+    except Exception as e:
+        print(f"Fatal error: {e}", flush=True)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/polaris.py
+++ b/polaris.py
@@ -3,6 +3,7 @@ import urllib
 import math
 import aiohttp
 import asyncio
+import time
 
 import json
 
@@ -15,9 +16,11 @@ ISSUE_SEVERITY_RANKS = {
 }
 
 class Polaris:
-    def __init__(self, url, token):
+    def __init__(self, url, token, retries, wait_seconds):
         self._baseurl = url
         self._client = requests.Session()
+        self._retries = retries
+        self._wait_seconds = wait_seconds
         self._jwt = self.getJwt(token)
 
     def __del__(self):
@@ -35,45 +38,45 @@ class Polaris:
         auth_headers = {'Content-Type': 'application/x-www-form-urlencoded'}
         auth_params = {'accesstoken': token}
 
-        try:
-            response = self._client.post(self.getFullUrl('/api/auth/authenticate'), headers=auth_headers, data=auth_params)
-
-            if response.status_code == 200:
-                json_payload = response.json()
-
-                return json_payload['jwt']
-        except:
-            print('Failed to authenticate')
-            raise
+        for attempt in range(self._retries):
+            try:
+                response = self._client.post(
+                    self.getFullUrl('/api/auth/authenticate'),
+                    headers=auth_headers,
+                    data=auth_params
+                )
+                if response.status_code == 200:
+                    json_payload = response.json()
+                    return json_payload['jwt']
+                else:
+                    raise Exception(f"HTTP {response.status_code}")
+            except Exception as e:
+                if attempt < self._retries - 1:
+                    print(f"Warning: Failed to authenticate with Polaris ({e}). Retrying in {self._wait_seconds} seconds...", flush=True)
+                    time.sleep(self._wait_seconds)
+                else:
+                    print(f"Failed to authenticate after {self._retries} attempts. Last error: {e}", flush=True)
+                    raise RuntimeError(
+                        f"Failed: Unexpected response from Polaris after {self._retries} attempts (HTTP {getattr(response, 'status_code', 'N/A')})"
+                    )
         return None
 
     def GetApplication(self, application_id):
-        response = self._client.get(self.getFullUrl(f'/api/common/v0/applications/{application_id}'),
-                                headers=self._getHeaders())
-
-        return response.json()
+        url = self.getFullUrl(f'/api/common/v0/applications/{application_id}')
+        return self._request_with_retries("GET", url, headers=self._getHeaders())
 
     def GetProjectsFromApplication(self, application_id):
-        response = self._client.get(
-            self.getFullUrl('/api/common/v0/projects') + f'?page[limit]=500&application-id={application_id}&include[project][]=branches&include[project][]=runs',
-            headers=self._getHeaders())
-
-        return response.json()
+        url = self.getFullUrl('/api/common/v0/projects') + f'?page[limit]=500&application-id={application_id}&include[project][]=branches&include[project][]=runs'
+        return self._request_with_retries("GET", url, headers=self._getHeaders())
 
     def GetProjectsByCustomProperty(self, **kwargs):
         custom_properties = "&".join("filter[project][properties][{}][$eq]={}".format(*i) for i in kwargs.items())
-        response = self._client.get(
-            self.getFullUrl('/api/common/v0/projects') + f'?page[limit]=500&{custom_properties}&include[project][]=branches&include[project][]=runs',
-            headers=self._getHeaders())
-
-        return response.json()
+        url = self.getFullUrl('/api/common/v0/projects') + f'?page[limit]=500&{custom_properties}&include[project][]=branches&include[project][]=runs'
+        return self._request_with_retries("GET", url, headers=self._getHeaders())
 
     def _getProjects(self):
-        response = self._client.get(self.getFullUrl(
-            '/api/common/v0/projects') + '?page[limit]=500&include[project][]=branches&include[project][]=runs',
-                                headers=self._getHeaders())
-
-        return response.json()
+        url = self.getFullUrl('/api/common/v0/projects') + '?page[limit]=500&include[project][]=branches&include[project][]=runs'
+        return self._request_with_retries("GET", url, headers=self._getHeaders())
 
     async def _getPaginatedIssuePage(self, session, project_id, branch_id, limit, offset, filter):
         query_args = [
@@ -94,8 +97,18 @@ class Polaris:
             query_args += ["filter[issue][triage-status][$eq]=not-triaged"]
 
         request_url = self.getFullUrl('/api/query/v1/issues' + '?' + '&'.join(query_args))
-        async with session.get(request_url, headers=self._getHeaders()) as response:
-            return await response.json()
+        for attempt in range(self._retries):
+            async with session.get(request_url, headers=self._getHeaders()) as response:
+                try:
+                    return await response.json()
+                except Exception:
+                    if attempt < self._retries - 1:
+                        print(f"Warning: Unexpected response from Polaris (HTTP {response.status}). Retrying in {self._wait_seconds} seconds...", flush=True)
+                        await asyncio.sleep(self._wait_seconds)
+                    else:
+                        raise RuntimeError(
+                            f"Failed: Unexpected response from Polaris after {self._retries} attempts (HTTP {response.status})"
+                        )
 
     async def _getPaginatedIssues(self, session, project_id, branch_id, filter):
         first_page = await self._getPaginatedIssuePage(session, project_id, branch_id, 500, 0, filter)
@@ -149,7 +162,7 @@ class Polaris:
 
         data = issues['data']
         if len(data) > 0:
-            print(project_name)
+            print(project_name, flush=True)
             untriaged_filter = filter.copy()
             untriaged_filter['only-untriaged'] = True
             return {
@@ -262,3 +275,17 @@ class Polaris:
 
         # Sort by severity rank, issue-type and path
         return sorted(issues, key=lambda x: (int(ISSUE_SEVERITY_RANKS[x['severity']]), x['issue-type'], x['path']))
+
+    def _request_with_retries(self, method, url, **kwargs):
+        for attempt in range(self._retries):
+            response = self._client.request(method, url, **kwargs)
+            try:
+                return response.json()
+            except Exception:
+                if attempt < self._retries - 1:
+                    print(f"Warning: Unexpected response from Polaris (HTTP {response.status_code}). Retrying in {wait_seconds} seconds...", flush=True)
+                    time.sleep(self._wait_seconds)
+                else:
+                    raise RuntimeError(
+                        f"Failed: Unexpected response from Polaris after {self._retries} attempts (HTTP {response.status_code})"
+                    )


### PR DESCRIPTION
# Changes

- Added retries and sleep before retries in all methods that expect a JSON in the response in polaris.py.
- POLARIS_RETRIES and POLARIS_WAIT_SECONDS are configurable through env variables, but default to 1 and 60 respectively (should not affect current usages, default behavior is same as not having retries).
- Added Flush=True to all print to synchronously print all information, if not it would only print after all sleep calls finish.
- Added try except in main.py to fail gracefully.