### PR TITLE
Add logging, filter for untriaged for slack too

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,17 @@
 import json
 import logging
 import sys
+import datetime
 from os import environ
 
 from polaris import Polaris
 from slack import Slack
 from google import Google
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(name)s %(message)s'
+   )
 
 logger = logging.getLogger('polaris-slack')
 
@@ -27,7 +33,7 @@ def main():
         google_spaces_url = environ.get('GOOGLE_SPACES_URL')
         if (not slack_webhook_url) and (not google_spaces_url):
             logger.warning("Environment SLACK_WEBHOOK and GOOGLE_SPACES_URL is unset, just outputting issues to console.")
-
+        logger.info(f"Polaris starting at {datetime.datetime.now().isoformat()}")
         polaris = Polaris(polaris_url, token, retries=retries, wait_seconds=wait_seconds)
 
         filter = {
@@ -37,11 +43,16 @@ def main():
         filter_untriaged = filter.copy()
         filter_untriaged['only-untriaged'] = True
 
+        logger.info(f"Polaris GetProjectsAndIssues {filter} at {datetime.datetime.now().isoformat()}")
         projects_with_issues = polaris.GetProjectsAndIssues(filter)
 
         if slack_webhook_url:
+            logger.info(f"Polaris GetProjectsAndIssues {filter_untriaged} at {datetime.datetime.now().isoformat()}")
+            projects_with_untriaged_issues = polaris.GetProjectsAndIssues(filter_untriaged)
             slack = Slack(slack_webhook_url)
+            logger.info(f"Slack SendSummaryPerProjects at {datetime.datetime.now().isoformat()}")
             slack.SendSummaryPerProjects(projects_with_issues, filter)
+            slack.SendSummaryPerProjects(projects_with_untriaged_issues, filter_untriaged)
         elif google_spaces_url:
             projects_with_untriaged_issues = polaris.GetProjectsAndIssues(filter_untriaged)
             google = Google(google_spaces_url)
@@ -50,7 +61,9 @@ def main():
             print(json.dumps(projects_with_issues, indent=2))
     except Exception as e:
         print(f"Fatal error: {e}", flush=True)
+        logger.critical(f"Fatal error: {e}", exc_info=True)
         sys.exit(1)
+    logger.info(f"Finished at {datetime.datetime.now().isoformat()}")
 
 if __name__ == '__main__':
     main()

--- a/slack.py
+++ b/slack.py
@@ -3,7 +3,6 @@ from slack_sdk.models.blocks import SectionBlock, MarkdownTextObject, HeaderBloc
 
 
 class Slack:
-    slack_message = []
     severity_colors = {
         "Audit": ":large_white_square:",
         "Low": ":large_yellow_square:",
@@ -13,6 +12,7 @@ class Slack:
 
     def __init__(self, webhook_url):
         self.webhook = WebhookClient(webhook_url)
+        self.slack_message = []
 
     def appendOrSend(self, block):
         if len(self.slack_message) >= 50:
@@ -28,6 +28,7 @@ class Slack:
             text="fallback",
             blocks=self.slack_message
         )
+        self.slack_message = []
 
     def GetIssueCount(self, issues):
         issue_counts = {}

--- a/slack.py
+++ b/slack.py
@@ -9,10 +9,12 @@ class Slack:
         "Medium": ":large_orange_square:",
         "High": ":large_red_square:"
     }
+    def __clearMessages(self):
+        self.slack_message = []
 
     def __init__(self, webhook_url):
         self.webhook = WebhookClient(webhook_url)
-        self.slack_message = []
+        self.__clearMessages()
 
     def appendOrSend(self, block):
         if len(self.slack_message) >= 50:
@@ -20,7 +22,7 @@ class Slack:
                 text="fallback",
                 blocks=self.slack_message
             )
-            self.slack_message = []
+            self.__clearMessages()
         self.slack_message.append(block)
 
     def flush(self):
@@ -28,7 +30,7 @@ class Slack:
             text="fallback",
             blocks=self.slack_message
         )
-        self.slack_message = []
+        self.__clearMessages()
 
     def GetIssueCount(self, issues):
         issue_counts = {}


### PR DESCRIPTION
add logging to see how long it takes to get the response from polaris
filter for untriaged as well in order to send to slack both report on all issues and untriaged ones at once
clean the buffer from slack after sending the messages
<img width="1095" height="463" alt="image" src="https://github.com/user-attachments/assets/13e785ec-5a17-4347-a2b8-1795b9cadd62" />
